### PR TITLE
format: move </svelte:head> onto new line

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -9,7 +9,7 @@
 	<link
 		href="https://fonts.googleapis.com/css2?family=Patrick+Hand+SC&display=swap"
 		rel="stylesheet"
-	/></svelte:head
->
+	/>
+</svelte:head>
 
 <slot />


### PR DESCRIPTION
Changes made in this PR:

In `/src/routes/+layout.svelte`, the closing `</svelte:head>` tag was placed awkwardly. Fortunately, this PR resolves the glaring formatting inconsistency by taking the open-source liberty of transferring the portion of the closing tag on the same line as the end of the final `link` tag to the next line. The commit(s) in the PR affect only the `+layout.svelte` file, increasing readability.

Indeed, this PR is vital to the repository because just a small investment in the maintainability of a codebase makes it easier to pick it up after a break and can provide you with an insurance policy should the source from this relatively disposable software turn out more useful than originally thought.

Thanks for your time in considering this change.